### PR TITLE
Remove randomWaterdrop function recursive call

### DIFF
--- a/Sources/WaterDropsView.swift
+++ b/Sources/WaterDropsView.swift
@@ -21,7 +21,7 @@ open class WaterDropsView: UIView {
         case up
         case down
     }
-
+    
     ///Waterdrop's color
     open var color: UIColor = UIColor.blue.withAlphaComponent(0.7)
     ///The minimum size of a waterdrop
@@ -100,24 +100,17 @@ open class WaterDropsView: UIView {
         
         // make waterdrop
         let positionY = direction == .up ? self.frame.height : -randomSize
-        var waterdrop : UIView? = UIView()
-        waterdrop?.frame = CGRect(x: randomX, y: positionY, width: randomSize, height: randomSize)
-        waterdrop?.backgroundColor = config.color
-        waterdrop?.layer.cornerRadius = randomSize/2
-        self.addSubview(waterdrop!)
+        let waterdrop : UIView = UIView()
+        waterdrop.frame = CGRect(x: randomX, y: positionY, width: randomSize, height: randomSize)
+        waterdrop.backgroundColor = config.color
+        waterdrop.layer.cornerRadius = randomSize/2
+        self.addSubview(waterdrop)
         
         // animation
-        UIView.animate(withDuration: randomDuration, animations: {
-            waterdrop?.frame.origin.y += length
-            waterdrop?.alpha = 0.0
-        }, completion: { (isCompleted: Bool) -> Void in
-            if isCompleted {
-                waterdrop = nil
-                
-                // After animation is completed, it recreate oneself
-                self.randomWaterdrop(config: config, direction: direction)
-            }
-        })
+        UIView.animate(withDuration: randomDuration, delay: 0.0, options: .repeat, animations: {
+            waterdrop.frame.origin.y += length
+            waterdrop.alpha = 0.0
+        }, completion: nil)
     }
     
     fileprivate struct ViewConfig {


### PR DESCRIPTION
- randomWaterdrop을 재귀호출 하도록 되어있는 것이 애니메이션의 반복을 위한 것처럼 보여집니다.
- 만약, waterdrop의 위치를 애니메이션마다 랜덤으로 바꿔주려고 하셨던 것이라면 이 풀리퀘를 무시하셔도 됩니다!
- 따라서 재귀호출 구문을 제거하고 애니메이션의 repeat 옵션을 통하여 애니메이션을 반복하도록 변경해보았습니다.
(애니메이션 completion handler에 원래의 상태로 넣어주는 구문을 빼먹었네요!..)